### PR TITLE
feat: add feature to save mushroom images in the FS

### DIFF
--- a/app/Controllers/MushroomsController.php
+++ b/app/Controllers/MushroomsController.php
@@ -41,10 +41,62 @@ class MushroomsController extends Controller
         $this->render('mushrooms/new', compact('mushroom', 'title'));
     }
 
+    public function edit(Request $request): void
+    {
+        $params = $request->getParams();
+        $mushroom = Mushroom::findById($params['id']);
+
+        $title = "Editar Cogumelo #{$mushroom->id}";
+        $this->render('mushrooms/edit', compact('mushroom', 'title'));
+    }
+
     public function create(Request $request): void
     {
         $params = $request->getParam('mushroom');
         $mushroom = new Mushroom($params);
+
+        $file = $_FILES['image_file'] ?? null;
+
+        if ($file && $file['error'] === UPLOAD_ERR_OK) {
+            $maxFileSize = 2 * 1024 * 1024; // 2MB
+            $allowedTypes = ['image/jpeg', 'image/png', 'image/jpg'];
+
+            if ($file['size'] > $maxFileSize) {
+                FlashMessage::danger('A imagem excede o tamanho máximo permitido de 2MB.');
+                $title = 'Novo Cogumelo';
+                $this->render('mushrooms/new', compact('mushroom', 'title'));
+                return;
+            }
+
+            if (!in_array(mime_content_type($file['tmp_name']), $allowedTypes)) {
+                FlashMessage::danger('Formato de imagem inválido. Utilize JPEG, PNG ou JPG.');
+                $title = 'Novo Cogumelo';
+                $this->render('mushrooms/new', compact('mushroom', 'title'));
+                return;
+            }
+
+            $uploadDir = __DIR__ . '/../../public/uploads';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+
+            $filename = uniqid() . '_' . basename($file['name']);
+            $targetPath = $uploadDir . '/' . $filename;
+
+            if (move_uploaded_file($file['tmp_name'], $targetPath)) {
+                $mushroom->image_url = '/uploads/' . $filename;
+            } else {
+                FlashMessage::danger('Erro ao salvar a imagem. Tente novamente.');
+                $title = 'Novo Cogumelo';
+                $this->render('mushrooms/new', compact('mushroom', 'title'));
+                return;
+            }
+        } else {
+            FlashMessage::danger('Você precisa enviar uma imagem.');
+            $title = 'Novo Cogumelo';
+            $this->render('mushrooms/new', compact('mushroom', 'title'));
+            return;
+        }
 
         if ($mushroom->save()) {
             FlashMessage::success('Cogumelo registrado com sucesso!');
@@ -56,25 +108,66 @@ class MushroomsController extends Controller
         }
     }
 
-    public function edit(Request $request): void
-    {
-        $params = $request->getParams();
-        $mushroom = Mushroom::findById($params['id']);
-
-        $title = "Editar Cogumelo #{$mushroom->id}";
-        $this->render('mushrooms/edit', compact('mushroom', 'title'));
-    }
-
     public function update(Request $request): void
     {
         $id = $request->getParam('id');
         $params = $request->getParam('mushroom');
-
         $mushroom = Mushroom::findById($id);
+
+        if (!$mushroom) {
+            FlashMessage::danger('Cogumelo não encontrado.');
+            $this->redirectTo(route('mushrooms.index'));
+            return;
+        }
+
         $mushroom->scientific_name = $params['scientific_name'];
-        $mushroom->image_url = $params['image_url'];
         $mushroom->hint = $params['hint'];
         $mushroom->description = $params['description'];
+
+        $file = $_FILES['image_file'] ?? null;
+
+        if ($file && $file['error'] === UPLOAD_ERR_OK) {
+            $maxFileSize = 2 * 1024 * 1024; // 2MB
+            $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/jpg'];
+
+            if ($file['size'] > $maxFileSize) {
+                FlashMessage::danger('A imagem excede o tamanho máximo permitido de 2MB.');
+                $title = "Editar Cogumelo #{$mushroom->id}";
+                $this->render('mushrooms/edit', compact('mushroom', 'title'));
+                return;
+            }
+
+            if (!in_array(mime_content_type($file['tmp_name']), $allowedTypes)) {
+                FlashMessage::danger('Formato de imagem inválido. Utilize JPEG, PNG ou GIF.');
+                $title = "Editar Cogumelo #{$mushroom->id}";
+                $this->render('mushrooms/edit', compact('mushroom', 'title'));
+                return;
+            }
+
+            $uploadDir = __DIR__ . '/../../public/uploads';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+
+            $filename = uniqid() . '_' . basename($file['name']);
+            $targetPath = $uploadDir . '/' . $filename;
+
+            if (move_uploaded_file($file['tmp_name'], $targetPath)) {
+                if ($mushroom->image_url) {
+                    $oldImagePath = __DIR__ . '/../../public' . $mushroom->image_url;
+                    if (file_exists($oldImagePath)) {
+                        unlink($oldImagePath);
+                    }
+                }
+
+                $mushroom->image_url = '/uploads/' . $filename;
+            } else {
+                FlashMessage::danger('Erro ao salvar a imagem. Tente novamente.');
+                $title = "Editar Cogumelo #{$mushroom->id}";
+                $this->render('mushrooms/edit', compact('mushroom', 'title'));
+                return;
+            }
+        }
 
         if ($mushroom->save()) {
             FlashMessage::success('Cogumelo atualizado com sucesso!');

--- a/app/Models/Mushroom.php
+++ b/app/Models/Mushroom.php
@@ -23,7 +23,10 @@ class Mushroom extends Model
         Validations::notEmpty('scientific_name', $this);
         Validations::uniqueness('scientific_name', $this);
 
-        Validations::notEmpty('image_url', $this);
+        if (empty($this->image_url)) {
+            Validations::notEmpty('image_url', $this);
+        }
+
         Validations::notEmpty('hint', $this);
         Validations::notEmpty('description', $this);
     }

--- a/app/views/mushrooms/edit.phtml
+++ b/app/views/mushrooms/edit.phtml
@@ -1,40 +1,36 @@
-<head>
-    <script src="https://unpkg.com/feather-icons"></script>
-    <style>
-        a.btn i[data-feather] {
-            width: 1em;
-            height: 1em;
-            vertical-align: middle;
-            stroke-width: 2;
-            margin-right: 0.25em;
-        }
-    </style>
-</head>
-
-<form action="<?= route('mushrooms.update', ['id' => $mushroom->id]) ?>" method="POST" class="<?= $mushroom->hasErrors() ? 'was-validated' : '' ?>" novalidate>
+<form action="<?= route('mushrooms.update', ['id' => $mushroom->id]) ?>" method="POST" enctype="multipart/form-data" class="<?= $mushroom->hasErrors() ? 'was-validated' : '' ?>" novalidate>
     <input type="hidden" name="_method" value="PUT">
 
     <div class="mb-3">
         <label for="scientific_name" class="form-label">Nome Científico</label>
-        <input type="text" value="<?= $mushroom->scientific_name ?>" name="mushroom[scientific_name]" class="form-control" id="scientific_name" required>
+        <input type="text" value="<?= htmlspecialchars($mushroom->scientific_name) ?>" name="mushroom[scientific_name]" class="form-control" id="scientific_name" required>
         <div class="invalid-feedback"><?= $mushroom->errors('scientific_name') ?? '' ?></div>
     </div>
 
     <div class="mb-3">
-        <label for="image_url" class="form-label">URL da Imagem</label>
-        <input type="url" value="<?= $mushroom->image_url ?>" name="mushroom[image_url]" class="form-control" id="image_url" required>
+        <label class="form-label">Imagem Atual</label><br>
+        <?php if ($mushroom->image_url): ?>
+            <img src="<?= htmlspecialchars($mushroom->image_url) ?>" alt="<?= htmlspecialchars($mushroom->scientific_name) ?>" class="img-thumbnail mb-2" style="max-width: 200px;">
+        <?php else: ?>
+            <em>Nenhuma imagem cadastrada.</em>
+        <?php endif; ?>
+    </div>
+
+    <div class="mb-3">
+        <label for="image_file" class="form-label">Nova Imagem (opcional)</label>
+        <input type="file" name="image_file" accept="image/*" class="form-control" id="image_file">
         <div class="invalid-feedback"><?= $mushroom->errors('image_url') ?? '' ?></div>
     </div>
 
     <div class="mb-3">
         <label for="hint" class="form-label">Dica</label>
-        <input type="text" value="<?= $mushroom->hint ?>" name="mushroom[hint]" class="form-control" id="hint" required>
+        <input type="text" value="<?= htmlspecialchars($mushroom->hint) ?>" name="mushroom[hint]" class="form-control" id="hint" required>
         <div class="invalid-feedback"><?= $mushroom->errors('hint') ?? '' ?></div>
     </div>
 
     <div class="mb-3">
         <label for="description" class="form-label">Descrição</label>
-        <textarea name="mushroom[description]" class="form-control" id="description" required><?= $mushroom->description ?></textarea>
+        <textarea name="mushroom[description]" class="form-control" id="description" required><?= htmlspecialchars($mushroom->description) ?></textarea>
         <div class="invalid-feedback"><?= $mushroom->errors('description') ?? '' ?></div>
     </div>
 

--- a/app/views/mushrooms/new.phtml
+++ b/app/views/mushrooms/new.phtml
@@ -11,7 +11,7 @@
     </style>
 </head>
 
-<form action="<?= route('mushrooms.create') ?>" method="POST" class="<?= $mushroom->hasErrors() ? 'was-validated' : '' ?>" novalidate>
+<form action="<?= route('mushrooms.create') ?>" method="POST" enctype="multipart/form-data" class="<?= $mushroom->hasErrors() ? 'was-validated' : '' ?>" novalidate>
     <div class="mb-3">
         <label for="scientific_name" class="form-label">Nome Científico</label>
         <input type="text" value="<?= $mushroom->scientific_name ?>" name="mushroom[scientific_name]" class="form-control" id="scientific_name" required>
@@ -19,8 +19,8 @@
     </div>
 
     <div class="mb-3">
-        <label for="image_url" class="form-label">URL da Imagem</label>
-        <input type="url" value="<?= $mushroom->image_url ?>" name="mushroom[image_url]" class="form-control" id="image_url" required>
+        <label for="image_file" class="form-label">Imagem</label>
+        <input type="file" name="image_file" accept="image/*" class="form-control" id="image_file" required>
         <div class="invalid-feedback"><?= $mushroom->errors('image_url') ?? '' ?></div>
     </div>
 

--- a/app/views/mushrooms/show.phtml
+++ b/app/views/mushrooms/show.phtml
@@ -15,8 +15,8 @@
     <div class="card mx-auto mt-3" style="max-width: 500px;">
         <div class="card-body text-center">
             <h5 class="card-title mb-3"><?= htmlspecialchars($mushroom->scientific_name) ?></h5>
-            <p><strong>Description:</strong><br> <?= nl2br(htmlspecialchars($mushroom->description ?? '')) ?></p>
-            <p><strong>Hint:</strong><br> <?= htmlspecialchars($mushroom->hint ?? '') ?></p>
+            <p><strong>Descrição:</strong><br> <?= nl2br(htmlspecialchars($mushroom->description ?? '')) ?></p>
+            <p><strong>Dica:</strong><br> <?= htmlspecialchars($mushroom->hint ?? '') ?></p>
         </div>
 
         <?php
@@ -27,7 +27,7 @@
                 src="<?= htmlspecialchars($img) ?>"
                 alt="<?= htmlspecialchars($mushroom->scientific_name) ?>"
                 class="img-fluid mt-3"
-                style="max-width: 100%; height: auto; display: block; margin: 0 auto;">
+                style="max-width: 100%; height: auto; display: block; margin: 0 auto 1.5rem;">
         <?php else: ?>
             <p class="text-center"><em>Imagem não disponível</em></p>
         <?php endif; ?>


### PR DESCRIPTION
This PR introduces functionality to save uploaded mushroom images directly to the file system (FS), enabling persistent local storage of image assets associated with mushroom data.